### PR TITLE
Small change to matmul-16 that prevents the DMA from circling data in last iteration

### DIFF
--- a/apps/matmul-16/device/src/matmul_main.c
+++ b/apps/matmul-16/device/src/matmul_main.c
@@ -217,13 +217,13 @@ void bigmatmul()
 					// Swap A banks horizontally
 					src = me.bank_A[me.pingpong];
 					dst = me.tgt_A[me.pingpong];
-					if (kc <= (_Nside - 1)) 
+					if (kc < (_Nside - 1)) 
 						data_copy(&dma_desc[1], dst, src);
 
 					// Swap B banks vertically
 					src = me.bank_B[me.pingpong];
 					dst = me.tgt_B[me.pingpong];
-					if (kc <= (_Nside - 1))
+					if (kc < (_Nside - 1))
 						data_copy(&dma_desc[1], dst, src);
 
 					me.pingpong = 1 - me.pingpong;


### PR DESCRIPTION
This is a very small suggestion, to the code. In the current implementation the code encapsulates the DMA transfer with an if-statement, intended to prevent the transfer  from happening in the last iteration. Unfortunately, the "<=" cancels out this effect. The impact of this change is close to zero (~1ms), but it is more in line with the original algorithm.

Best Regards Simon Thorsteinsson  