### PR TITLE
Correct minor typo in e-toggle-led

### DIFF
--- a/apps/e-toggle-led/src/e-toggle-led.c
+++ b/apps/e-toggle-led/src/e-toggle-led.c
@@ -85,7 +85,7 @@ void usage(){
   printf("Usage: e-toggle-led <state>\n\n");
   printf("<state>:\n");
   printf(" 1 = LED On\n");
-  printf(" 0 = LED Offf\n");
+  printf(" 0 = LED Off\n");
 }
 
  


### PR DESCRIPTION
Fixes a trivial typographical error in the e-toggle-led application ('offf' to 'off')